### PR TITLE
Import OrderedDict from collections

### DIFF
--- a/django_remote_forms/fields.py
+++ b/django_remote_forms/fields.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.conf import settings
-from django.utils.datastructures import OrderedDict
+from collections import OrderedDict
 
 from django_remote_forms import logger, widgets
 

--- a/django_remote_forms/utils.py
+++ b/django_remote_forms/utils.py
@@ -1,5 +1,5 @@
 from django.utils.functional import Promise
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 
 def resolve_promise(o):
@@ -10,7 +10,7 @@ def resolve_promise(o):
         o = [resolve_promise(x) for x in o]
     elif isinstance(o, Promise):
         try:
-            o = force_text(o)
+            o = force_str(o)
         except:
             # Item could be a lazy tuple or list
             try:


### PR DESCRIPTION
Previously, OrderedDict was imported from `django.utils.datastructures`, which does not exist anymore in Django 3. The base repository has switched to importing it from `collections` instead in commit https://github.com/thorgate/django-remote-forms/commit/5cd85b9444818ad882a020c772d6a61a4e8451f1. This MR adds this import change to our fork.

This is tested on MHV when doing the upgrade from Django 2.2 to 3.2. However, the original source did this change already for supporting Django 1.11, so in theory it should work for other versions as well. 